### PR TITLE
Fix/update cli name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ This repository contains the source code for `zkdoc_sdk`, `zkdoc_cli` and `zkdoc
 cargo build -p core_cli --release
 ```
 ```bash
-Medi0 CLI
+ZKDoc CLI
 
-Usage: core_cli [COMMAND]
+Usage: zkdoc_cli [COMMAND]
 
 Commands:
   gen-commitment  Generates a commitment for a given file

--- a/zkdoc_cli/src/main.rs
+++ b/zkdoc_cli/src/main.rs
@@ -34,10 +34,10 @@ fn save_to_file(filename: &str, data: &str) -> Result<(), std::io::Error> {
 }
 
 fn main() {
-    let cmd = clap::Command::new("medi0-cli")
-        .about("Medi0 CLI")
+    let cmd = clap::Command::new("zkdoc-cli")
+        .about("ZKDoc CLI")
         .version("0.1.0")
-        .author("Medi0 Team")
+        .author("ZKDoc Team")
         .subcommand(
             Command::new("gen-commitment")
                 .about("Generates a commitment for a given file")


### PR DESCRIPTION
changes:
- renamed `medi0` to `zkdoc` in the CLI and Readme